### PR TITLE
feat(unidialog-packetevents): add configuration phase support in packet sending

### DIFF
--- a/packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java
+++ b/packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java
@@ -26,7 +26,7 @@ public class PEDialogOpener implements DialogOpener {
         Object player = playerFunction.apply(uuid);
         if (player == null) return false;
 
-      User user = PacketEvents.getAPI().getPlayerManager().getUser(uuid);
+      User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
 
       if(user.getConnectionState() == ConnectionState.CONFIGURATION) {
         WrapperConfigServerShowDialog wrapper = new WrapperConfigServerShowDialog(dialog);

--- a/packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java
+++ b/packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java
@@ -1,7 +1,10 @@
 package io.github.projectunified.unidialog.packetevents.opener;
 
 import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.ConnectionState;
 import com.github.retrooper.packetevents.protocol.dialog.Dialog;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.wrapper.configuration.server.WrapperConfigServerShowDialog;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerShowDialog;
 import io.github.projectunified.unidialog.core.opener.DialogOpener;
 import org.jetbrains.annotations.Nullable;
@@ -22,6 +25,14 @@ public class PEDialogOpener implements DialogOpener {
     public boolean open(UUID uuid) {
         Object player = playerFunction.apply(uuid);
         if (player == null) return false;
+
+      User user = PacketEvents.getAPI().getPlayerManager().getUser(uuid);
+
+      if(user.getConnectionState() == ConnectionState.CONFIGURATION) {
+        WrapperConfigServerShowDialog wrapper = new WrapperConfigServerShowDialog(dialog);
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, wrapper);
+        return true;
+      }
 
         WrapperPlayServerShowDialog wrapper = new WrapperPlayServerShowDialog(dialog);
         PacketEvents.getAPI().getPlayerManager().sendPacket(player, wrapper);


### PR DESCRIPTION
This pull request updates the `PEDialogOpener` class in the `packetevents` module to add support for handling players in the `CONFIGURATION` connection state. The changes introduce new imports and logic to conditionally send a different packet type based on the player's connection state.

### Updates to connection state handling:

* [`packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java`](diffhunk://#diff-9ac848d41d3f5afd31cc34affca485fcb81179ae4db45685e24b4a20831997b9R4-R7): Added imports for `ConnectionState`, `User`, and `WrapperConfigServerShowDialog` to support new functionality.
* [`packetevents/src/main/java/io/github/projectunified/unidialog/packetevents/opener/PEDialogOpener.java`](diffhunk://#diff-9ac848d41d3f5afd31cc34affca485fcb81179ae4db45685e24b4a20831997b9R29-R36): Updated the `open` method to check if the player's connection state is `CONFIGURATION`. If true, it sends a `WrapperConfigServerShowDialog` packet instead of the default `WrapperPlayServerShowDialog` packet.